### PR TITLE
Will disable reindexation of Catalog Search index

### DIFF
--- a/src/Model/Indexer/Fulltext/Action/Full.php
+++ b/src/Model/Indexer/Fulltext/Action/Full.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @category    ScandiPWA
+ * @package     ScandiPWA_Performance
+ * @author      Raivis Dejus <info@scandiweb.com>
+ * @copyright   Copyright (c) 2020 Scandiweb, Ltd (https://scandiweb.com)
+ */
+
+declare(strict_types=1);
+
+namespace ScandiPWA\Performance\Model\Indexer\Fulltext\Action;
+
+/**
+ * PWA does not use "Catalog Search" ("catalogsearch_fulltext") index
+ * Index rebuild for a store will do nothing to avoid unnecessary DB load
+ */
+class Full extends \Magento\CatalogSearch\Model\Indexer\Fulltext\Action\Full
+{
+    public function rebuildStoreIndex($storeId, $productIds = null)
+    {
+        return; yield;
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -25,4 +25,6 @@
             </argument>
         </arguments>
     </type>
+    <preference for="Magento\CatalogSearch\Model\Indexer\Fulltext\Action\Full"
+                type="ScandiPWA\Performance\Model\Indexer\Fulltext\Action\Full"/>
 </config>


### PR DESCRIPTION
As far as I am aware ScandiPWA use custom way of searching and filtering products, the default Magneto way from `module-catalog-search` is not used. This module originally relies on "Catalog Search" (`catalogsearch_fulltext`) index that is bringing all the attributes used for search and filtering to a single table e.g. `catalogsearch_fulltext_scope1`

On larger production databases re-indexation of this index can cause unnecessary load on the database