### PR TITLE
[FIX] Skipped product attribute 'Used in Product Listing'.

### DIFF
--- a/src/Model/Resolver/Products/DataPostProcessor/Attributes.php
+++ b/src/Model/Resolver/Products/DataPostProcessor/Attributes.php
@@ -286,15 +286,11 @@ class Attributes implements ProductsDataPostProcessorInterface
         Attribute $attribute,
         bool $isSingleProduct
     ): bool {
-        if ($isSingleProduct) {
-            return !$attribute->getIsVisibleOnFront(); // skip attribute if is is not visible on FE
-        }
-
         /**
-         * On PLP, KEEP attribute if it is used on PLP and is visible on FE.
-         * This means if not visible on PLP or is not visible we should SKIP it.
+         * On PLP, KEEP attribute if it is used on PLP.
+         * This means if not visible on PLP we should SKIP it.
          */
-        return !$attribute->getUsedInProductListing() || !$attribute->getIsVisibleOnFront();
+        return !$attribute->getUsedInProductListing();
     }
 
     /**


### PR DESCRIPTION
A product attribute should always be present on the PLP when 'Used in Product Listing' is set to 'Yes', according to the Magento 2 documentation ([click here](https://docs.magento.com/user-guide/stores/attributes-product.html#storefront-properties)).

PR for https://github.com/scandipwa/performance/issues/8

