### PR TITLE
#1650 Remove empty attributes from response

### DIFF
--- a/src/Model/Resolver/Products/DataPostProcessor/Attributes.php
+++ b/src/Model/Resolver/Products/DataPostProcessor/Attributes.php
@@ -59,7 +59,7 @@ class Attributes implements ProductsDataPostProcessorInterface
      * @param Data $swatchHelper
      * @param CollectionFactory $productCollection
      * @param SearchCriteriaBuilder $searchCriteriaBuilder
-     * @param ProductAttributeRepositoryInterface $attributeRepositor
+     * @param ProductAttributeRepositoryInterface $attributeRepository
      */
     public function __construct(
         Data $swatchHelper,

--- a/src/Model/Resolver/Products/DataPostProcessor/Attributes.php
+++ b/src/Model/Resolver/Products/DataPostProcessor/Attributes.php
@@ -128,6 +128,7 @@ class Attributes implements ProductsDataPostProcessorInterface
 
                 if (!$attributeValue) {
                     // Remove all empty attributes
+                    unset($productAttributes[$productId][$attributeCode]);
                     continue;
                 }
 
@@ -290,7 +291,7 @@ class Attributes implements ProductsDataPostProcessorInterface
          * On PLP, KEEP attribute if it is used on PLP.
          * This means if not visible on PLP we should SKIP it.
          */
-        return !$attribute->getUsedInProductListing();
+        return !$attribute->getUsedInProductListing() || !$attribute->getStoreLabel();
     }
 
     /**


### PR DESCRIPTION
original issue: [1650](https://github.com/scandipwa/base-theme/issues/1650)

### Issue requirements
Don't need show these attributes:
- empty
- we see in another place (short description, URL and etc)

### In this PR:
- Removes attributes from response if ether value is not set or storefront label isn't set.