### PR TITLE
Add back check for attribute visible on storefront

### DIFF
--- a/src/Model/Resolver/Products/DataPostProcessor/Attributes.php
+++ b/src/Model/Resolver/Products/DataPostProcessor/Attributes.php
@@ -293,15 +293,20 @@ class Attributes implements ProductsDataPostProcessorInterface
         bool $isCompare
     ): bool {
         /**
+         * On PDP, If attribute is not visible on storefront
+         * or has no label then we should skip it.
+         *
          * On PLP, KEEP attribute if it is used on PLP.
          * This means if not visible on PLP we should SKIP it.
          *
-         * On PDP, If attribute has no label then it shouldn't be
-         * visible.
-         *
          * Don't skip if attribute is for the compare page
          */
-        $result = !$attribute->getUsedInProductListing() || !$attribute->getStoreLabel();
+
+        if ($isSingleProduct) {
+            return !$attribute->getIsVisibleOnFront() || !$attribute->getStoreLabel();
+        }
+
+        $result = !$attribute->getUsedInProductListing();
 
         if ($isCompare) {
             $result = !$attribute->getIsComparable() || !$attribute->getIsVisible();

--- a/src/Model/Resolver/Products/DataPostProcessor/Attributes.php
+++ b/src/Model/Resolver/Products/DataPostProcessor/Attributes.php
@@ -305,13 +305,11 @@ class Attributes implements ProductsDataPostProcessorInterface
             return !$attribute->getIsVisibleOnFront() || !$attribute->getStoreLabel();
         }
 
-        $result = !$attribute->getUsedInProductListing();
-
         if ($isCompare) {
-            $result = !$attribute->getIsComparable() || !$attribute->getIsVisible();
+            return !$attribute->getIsComparable() || !$attribute->getIsVisible();
         }
 
-        return $result;
+        return !$attribute->getUsedInProductListing();
     }
 
     /**

--- a/src/Model/Resolver/Products/DataPostProcessor/Attributes.php
+++ b/src/Model/Resolver/Products/DataPostProcessor/Attributes.php
@@ -301,7 +301,6 @@ class Attributes implements ProductsDataPostProcessorInterface
          *
          * Don't skip if attribute is for the compare page
          */
-
         if ($isSingleProduct) {
             return !$attribute->getIsVisibleOnFront() || !$attribute->getStoreLabel();
         }


### PR DESCRIPTION
fixes scandipwa/scandipwa#1951
Added back check for singleProduct attributes if they are visible on storefront.

Expected behavior:
If attribute is  visible on Catalog Pages on Storefront then get data and render it on PDP.
If attribute is Used in Product Listing then get data and render it on PLP.