### PR TITLE
Fix N/A attributes, remove empty attributes

### DIFF
--- a/src/Model/Resolver/Products/DataPostProcessor/Attributes.php
+++ b/src/Model/Resolver/Products/DataPostProcessor/Attributes.php
@@ -128,11 +128,6 @@ class Attributes implements ProductsDataPostProcessorInterface
 
                 // Remove all empty attributes
                 if (!$attributeValue) {
-                    // If attribute does not contain both value nor options then we remove it from output
-                    if (!isset($productAttributes[$productId][$attributeCode]) ||
-                        !$productAttributes[$productId][$attributeCode]['attribute_options']) {
-                        unset($productAttributes[$productId][$attributeCode]);
-                    }
                     continue;
                 }
 
@@ -200,6 +195,8 @@ class Attributes implements ProductsDataPostProcessorInterface
                     !isset($productAttributes[$id][$key]['attribute_value'])
                     && !count($variantAttributeValues)
                 ) {
+                    // Remove attribute if it has no value and empty options
+                    unset($productAttributes[$id][$key]);
                     continue;
                 }
 
@@ -376,6 +373,12 @@ class Attributes implements ProductsDataPostProcessorInterface
             }
         }
 
+        $this->appendWithValue(
+            $attributes,
+            $productIds,
+            $productAttributes
+        );
+
         if ($isCollectOptions) {
             $this->appendWithOptions(
                 $attributes,
@@ -384,12 +387,6 @@ class Attributes implements ProductsDataPostProcessorInterface
                 $productAttributes
             );
         }
-
-        $this->appendWithValue(
-            $attributes,
-            $productIds,
-            $productAttributes
-        );
 
         return function (&$productData) use ($productAttributes) {
             if (!isset($productData['entity_id'])) {


### PR DESCRIPTION
fixes scandipwa/scandipwa#1967

This should fix attributes type 'select' on simple products. N/A appears on FE because attribute has value, but option array is null.

Added remove from array attribute if it has no value and variantAttributeValues.