### PR TITLE
Performance improvement - attribute group data and swatch check scaling

### DIFF
--- a/src/Model/Resolver/Products/DataPostProcessor/Attributes.php
+++ b/src/Model/Resolver/Products/DataPostProcessor/Attributes.php
@@ -164,11 +164,15 @@ class Attributes implements ProductsDataPostProcessorInterface
             ->load();
 
         foreach ($attributeDataBySetId as $attributeSetId => $attributeData) {
+            $dataPath = sprintf('attribute_set_info/%s/group_id', $attributeSetId);
+
             foreach ($attributeData as $attributeCode => $data) {
+                $attributeGroupId = $attributes[$attributeCode]->getData($dataPath);
+
                 // Find the correct group for every attribute
                 /** @var AttributeGroupInterface $group */
                 foreach ($groupCollection as $group) {
-                    if ($attributes[$attributeCode]->isInGroup($attributeSetId, $group->getAttributeGroupId())) {
+                    if ($attributeGroupId ===  $group->getAttributeGroupId()) {
                         $attributeDataBySetId[$attributeSetId][$attributeCode]['attribute_group_name'] = $group->getAttributeGroupName();
                         $attributeDataBySetId[$attributeSetId][$attributeCode]['attribute_group_id'] = $group->getAttributeGroupId();
                         $attributeDataBySetId[$attributeSetId][$attributeCode]['attribute_group_code'] = $group->getAttributeGroupCode();
@@ -414,11 +418,14 @@ class Attributes implements ProductsDataPostProcessorInterface
                 if (!isset($attributes[$attributeCode])) {
                     $attributes[$attributeCode] = $attribute;
 
-                    // Collect all swatches (we will need additional data for them)
-                    if ($isCollectOptions && $this->swatchHelper->isSwatchAttribute($attribute)) {
-                        $swatchAttributes[] = $attributeCode;
-                    }
                 }
+            }
+        }
+
+        foreach ($attributes as $attributeCode => $attribute) {
+            // Collect all swatches (we will need additional data for them)
+            if ($isCollectOptions && $this->swatchHelper->isSwatchAttribute($attribute)) {
+                $swatchAttributes[] = $attributeCode;
             }
         }
 


### PR DESCRIPTION
Three issues popped up when trying to load PLP items data with high pageSize (e.g. 500 products).

First one is with the isInGroup() check.
It runs two things, first, an isInSet check, which reloads additional data and is redundant, as we have already sorted attributes by attribute set, and the logic is inside an attribute set loop.

Second, it runs getData() on the dataPath specified in the commit. That getData is getting dynamic data, meaning, it gets recalculated each time (or at least there's some uncached logic for sure).
It was being run inside of a loop on $groupColection, so I just moved it a level above, on the attribute.
It is probably still not as fast as a direct load of all the [attribute_id/attribute_set_id/attribute_group/id] map in a single call would be, but it is much faster anyway.

The third issue is with the swatches. Once again, isSwatchAttribute check is executing logic each time, but it doesn't change depending on attribute set.
I moved it into a separate loop by attributes.

Overall, for big collection load (500 products, 1000 unique visible on front attributes between them, and many attribute sets), it cut the time from 60 seconds to 25 seconds on my local; the data returned is the same.

It won't have nearly as much benefit on smaller product page loads / DBs with less unique visible on front attributes, but it is still a nice bonus.
And on big PLP collection loads(e.g. page cache warming extension that is in development), this will have significant impact.