### PR TITLE
#3570 - add salable quantity to qraphql response

### DIFF
--- a/src/Model/Resolver/Products/DataPostProcessor/Stocks.php
+++ b/src/Model/Resolver/Products/DataPostProcessor/Stocks.php
@@ -37,6 +37,8 @@ class Stocks implements ProductsDataPostProcessorInterface
 
     const STOCK_STATUS = 'stock_status';
 
+    const SALABLE_QTY = 'salable_qty';
+
     const IN_STOCK = 'IN_STOCK';
 
     const OUT_OF_STOCK = 'OUT_OF_STOCK';
@@ -199,6 +201,7 @@ class Stocks implements ProductsDataPostProcessorInterface
 
         foreach ($stockItems as $stockItem) {
             $leftInStock = null;
+            $productSalableQty = null;
             $qty = $stockItem->getQuantity();
             $sku = $stockItem->getSku();
 
@@ -233,7 +236,8 @@ class Stocks implements ProductsDataPostProcessorInterface
 
             $formattedStocks[$sku] = [
                 self::STOCK_STATUS => $inStock ? self::IN_STOCK : self::OUT_OF_STOCK,
-                self::ONLY_X_LEFT_IN_STOCK => $leftInStock
+                self::ONLY_X_LEFT_IN_STOCK => $leftInStock,
+                self::SALABLE_QTY => $productSalableQty
             ];
         }
 

--- a/src/etc/schema.graphqls
+++ b/src/etc/schema.graphqls
@@ -9,6 +9,7 @@ interface ProductInterface {
     thumbnail: OptimizedProductImage @resolver(class: "ScandiPWA\\Performance\\Model\\Resolver\\Value")
     only_x_left_in_stock: Float @resolver(class: "ScandiPWA\\Performance\\Model\\Resolver\\Value")
     stock_status: ProductStockStatus @resolver(class: "ScandiPWA\\Performance\\Model\\Resolver\\Value")
+    salable_qty: Float @resolver(class: "ScandiPWA\\Performance\\Model\\Resolver\\Value")
     s_attributes: [AttributeWithValue]
 }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes https://github.com/scandipwa/scandipwa/issues/3570

**Problem:**
* Missing field with salable quantity

**In this PR:**
* Added field `salable_qty`

**FE PR:** 
* https://github.com/scandipwa/scandipwa/pull/3621
