### PR TITLE
filtering the attributes and created new parameter 

### DIFF
--- a/src/Model/Resolver/Products/DataPostProcessor.php
+++ b/src/Model/Resolver/Products/DataPostProcessor.php
@@ -45,7 +45,8 @@ class DataPostProcessor
         string $graphqlResolvePath,
         $graphqlResolveInfo,
         array $processorOptions = [
-            'isSingleProduct' => false
+            'isSingleProduct' => false,
+            'isCartProduct'=> false
         ]
     ): array {
         $processorsCallbacks = array_map(function ($processor) use (

--- a/src/Model/Resolver/Products/DataPostProcessor/Attributes.php
+++ b/src/Model/Resolver/Products/DataPostProcessor/Attributes.php
@@ -385,8 +385,8 @@ class Attributes implements ProductsDataPostProcessorInterface
          * Don't skip if attribute is for the compare page
          */
         if (in_array($attribute->getId(), $this->configurableAttributeIds)) {
-            if(!$attribute->getUsedInProductListing() && !$isSingleProduct && !$isCartProduct){
-                    return true;
+            if(!$attribute->getUsedInProductListing() && !$isSingleProduct && !$isCartProduct) {
+                return true;
             }
             return false;
         }

--- a/src/Model/Resolver/Products/DataPostProcessor/Attributes.php
+++ b/src/Model/Resolver/Products/DataPostProcessor/Attributes.php
@@ -418,7 +418,7 @@ class Attributes implements ProductsDataPostProcessorInterface
 
         $isSingleProduct = isset($processorOptions['isSingleProduct']) ? $processorOptions['isSingleProduct'] : false;
         $isCompare = isset($processorOptions['isCompare']) ? $processorOptions['isCompare'] : false;
-        $isCartProduct = isset($processorOptions['isCartProduct']) ? $processorOptions['isCartProduct'] : true;
+        $isCartProduct = isset($processorOptions['isCartProduct']) ? $processorOptions['isCartProduct'] : false;
 
         $fields = $this->getFieldsFromProductInfo(
             $graphqlResolveInfo,

--- a/src/Model/Resolver/Products/DataPostProcessor/Attributes.php
+++ b/src/Model/Resolver/Products/DataPostProcessor/Attributes.php
@@ -368,7 +368,8 @@ class Attributes implements ProductsDataPostProcessorInterface
     protected function isAttributeSkipped(
         Attribute $attribute,
         bool $isSingleProduct,
-        bool $isCompare
+        bool $isCompare,
+        bool $isCartProduct
     ): bool {
         /**
          * If attribute is in configurable attribute pool, we need to
@@ -384,6 +385,9 @@ class Attributes implements ProductsDataPostProcessorInterface
          * Don't skip if attribute is for the compare page
          */
         if (in_array($attribute->getId(), $this->configurableAttributeIds)) {
+            if(!$attribute->getUsedInProductListing() && !$isSingleProduct && !$isCartProduct){
+                    return true;
+            }
             return false;
         }
 
@@ -414,6 +418,7 @@ class Attributes implements ProductsDataPostProcessorInterface
 
         $isSingleProduct = isset($processorOptions['isSingleProduct']) ? $processorOptions['isSingleProduct'] : false;
         $isCompare = isset($processorOptions['isCompare']) ? $processorOptions['isCompare'] : false;
+        $isCartProduct = isset($processorOptions['isCartProduct']) ? $processorOptions['isCartProduct'] : true;
 
         $fields = $this->getFieldsFromProductInfo(
             $graphqlResolveInfo,
@@ -446,7 +451,7 @@ class Attributes implements ProductsDataPostProcessorInterface
              * @var Attribute $attribute
              */
             foreach ($attributesArr as $attributeCode => $attribute) {
-                if ($this->isAttributeSkipped($attribute, $isSingleProduct, $isCompare)) {
+                if ($this->isAttributeSkipped($attribute, $isSingleProduct, $isCompare, $isCartProduct)) {
                     continue;
                 }
 


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa#4589

**Problem:**
* The configurable attribute was shown in the widgets even if they were disabled from the admin 

**In this PR:**
* Filtering the attributes if it is PLP or PDP and also created a new parameter in `quote-graphql` module and passing it for checking if the product is cartItem or not for showing all attributes there scandipwa/quote-graphql#96
